### PR TITLE
Cache clock element outside updateClock for performance

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,3 +1,5 @@
+const clockElement = document.getElementById("clock");
+
 function updateClock() {
   const now = new Date();
 
@@ -13,7 +15,6 @@ function updateClock() {
   const m = String(minutes).padStart(2, '0');
   const s = String(seconds).padStart(2, '0');
 
-  const clockElement = document.getElementById("clock");
   clockElement.textContent = `${h}:${m}:${s} ${ampm}`;
 }
 


### PR DESCRIPTION
This PR caches the DOM element with id "clock" outside the updateClock function to avoid querying the DOM every second, improving performance slightly without changing the UI or behavior.